### PR TITLE
为地图标记图片接入 wsrv 代理层

### DIFF
--- a/src/status/core/utils/index.ts
+++ b/src/status/core/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './assets';
 export * from './avatar-storage';
 export * from './format';
+export * from './marker-image-url';
 export * from './quality';
 export * from './session-storage';

--- a/src/status/core/utils/marker-image-url.ts
+++ b/src/status/core/utils/marker-image-url.ts
@@ -1,0 +1,17 @@
+const WSRV_HOST_PATTERN = /^https?:\/\/(?:[^/]+\.)?wsrv\.nl\//i;
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+
+/**
+ * 渲染阶段统一为地图标记图片接入 wsrv 代理，保持存储层仍使用原始外链。
+ * 当前版本只做最保守的 URL 包装；如果后续需要进一步降流量，
+ * 可以按缩略图/主图分别追加 w、h、fit、output 等参数。
+ */
+export const buildMarkerImageUrl = (url: string): string => {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl || !HTTP_URL_PATTERN.test(trimmedUrl) || WSRV_HOST_PATTERN.test(trimmedUrl)) {
+    return url;
+  }
+
+  const normalizedUrl = trimmedUrl.replace(HTTP_URL_PATTERN, '');
+  return `https://wsrv.nl/?url=${encodeURIComponent(normalizedUrl)}`;
+};

--- a/src/status/pages/map/components/map-tab-sections.tsx
+++ b/src/status/pages/map/components/map-tab-sections.tsx
@@ -8,6 +8,7 @@ import {
   markerIconLabels,
   markerIconOptions,
 } from '../../../core/utils/map-constants';
+import { buildMarkerImageUrl } from '../../../core/utils/marker-image-url';
 import styles from '../MapTab.module.scss';
 
 interface MapToolbarProps {
@@ -405,7 +406,7 @@ export const MarkerWorkbench: FC<MarkerWorkbenchProps> = ({
                           .map((url, index) => (
                             <div key={index} className={styles.imagePreviewItem}>
                               <img
-                                src={url}
+                                src={buildMarkerImageUrl(url)}
                                 alt={`预览 ${index + 1}`}
                                 className={styles.imagePreviewThumb}
                                 onError={event => {
@@ -587,7 +588,7 @@ export const MapStage: FC<MapStageProps> = ({
                         </button>
                       )}
                       <img
-                        src={activeImageUrl}
+                        src={buildMarkerImageUrl(activeImageUrl)}
                         alt={`${activeMarker.name || '标记'}主视觉`}
                         className={styles.mapMarkerCardHeroImage}
                         onError={event => {


### PR DESCRIPTION
**说明：不直接用猫箱链接而是接入了一个免费cdn服务 wsrv ，接入后可以提高稳定性且国内网络可以访问**

原链接 `https://files.catbox.moe/Fooi2lw.png` 修改后 `https://wsrv.nl/?url=files.catbox.moe%2Fooi2lw.png`

在地图标记图片的渲染阶段统一接入 wsrv.nl，仅代理缩略图预览和标记卡片主图，保持 imageUrls 仍然存储原始外链而不污染数据层。wsrv 作为图片代理与缓存层，可以为 Catbox 这类第三方图床提供更统一的访问入口，在大量标记图片场景下提升交付稳定性，并为后续按缩略图与主图分别追加尺寸、裁剪或格式参数预留扩展空间。


**TODO 修改版本号、build**
